### PR TITLE
Improve assertions and add pull_request trigger

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,6 @@
 name: CI
 
-on: [push]
+on: [push, pull_request]
 
 jobs:
   phpunit:

--- a/composer.json
+++ b/composer.json
@@ -35,6 +35,6 @@
     "require-dev": {
         "phpunit/phpunit": "~8.0",
         "symfony/process": "^5.0",
-        "vimeo/psalm": "~3.7.0"
+        "vimeo/psalm": "^3.7"
     }
 }

--- a/tests/Client/InternetTest.php
+++ b/tests/Client/InternetTest.php
@@ -63,7 +63,7 @@ class InternetTest extends TestCase
 
     public function testResource()
     {
-        $this->assertTrue(is_resource($this->client->resource()));
+        $this->assertIsResource($this->client->resource());
         $this->assertSame('stream', get_resource_type($this->client->resource()));
     }
 

--- a/tests/Client/UnixTest.php
+++ b/tests/Client/UnixTest.php
@@ -42,7 +42,7 @@ class UnixTest extends TestCase
 
     public function testResource()
     {
-        $this->assertTrue(is_resource($this->client->resource()));
+        $this->assertIsResource($this->client->resource());
         $this->assertSame('stream', get_resource_type($this->client->resource()));
     }
 

--- a/tests/Server/Connection/StreamTest.php
+++ b/tests/Server/Connection/StreamTest.php
@@ -38,7 +38,7 @@ class StreamTest extends TestCase
 
     public function testResource()
     {
-        $this->assertTrue(is_resource($this->stream->resource()));
+        $this->assertIsResource($this->stream->resource());
         $this->assertSame('stream', get_resource_type($this->stream->resource()));
     }
 

--- a/tests/Server/InternetTest.php
+++ b/tests/Server/InternetTest.php
@@ -52,7 +52,7 @@ class InternetTest extends TestCase
 
     public function testResource()
     {
-        $this->assertTrue(is_resource($this->server->resource()));
+        $this->assertIsResource($this->server->resource());
         $this->assertSame('stream', get_resource_type($this->server->resource()));
     }
 

--- a/tests/Server/UnixTest.php
+++ b/tests/Server/UnixTest.php
@@ -56,7 +56,7 @@ class UnixTest extends TestCase
     {
         $unix = Unix::recoverable(new Address(Path::of('/tmp/foo')));
 
-        $this->assertTrue(is_resource($unix->resource()));
+        $this->assertIsResource($unix->resource());
         $this->assertSame('stream', get_resource_type($unix->resource()));
     }
 
@@ -65,10 +65,10 @@ class UnixTest extends TestCase
         $unix = Unix::recoverable(new Address(Path::of('/tmp/foo')));
 
         $this->assertFalse($unix->closed());
-        $this->assertTrue(file_exists('/tmp/foo.sock'));
+        $this->assertFileExists('/tmp/foo.sock');
         $this->assertNull($unix->close());
         $this->assertTrue($unix->closed());
-        $this->assertFalse(file_exists('/tmp/foo.sock'));
+        $this->assertFileNotExists('/tmp/foo.sock');
     }
 
     public function testPosition()


### PR DESCRIPTION
# Changed log

- Using the `assertIsResource` to assert result type is `resource`.
- Using the `assertFileExists` to assert specific file path is existed.
- Using the `assertFileNotExists` to assert specific file path is not existed.
- Defining the `^3.7` for `Psalm` version to let Psalm install latest version.
- Add `pull_request` trigger on GitHub action.